### PR TITLE
Added the documentary Hackers: Wizards of the Electronic Age

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A curated list of computer history videos, documentaries and related folklore ma
 - [Silicon Valley](http://www.pbs.org/wgbh/americanexperience/films/silicon/) (2013) - A PBS "American Experience" documentary about the start of Silicon Valley <sup>[8.1/10](http://www.imdb.com/title/tt2547530/)</sup>
 - [Birth of BASIC](https://www.youtube.com/watch?v=WYPNjSoDrqw) (2014) - Invention of the Basic computer language.
 - [The Internet's Own Boy: The Story of Aaron Swartz](https://www.youtube.com/watch?v=vXr-2hwTk58) (2014) - The story of programming prodigy and information activist Aaron Swartz <sup>[8.1/10](http://www.imdb.com/title/tt3268458/)</sup>
+- [Hackers: Wizards of the Electronic Age](https://www.youtube.com/watch?v=cVCLowi4v7w) (1984) - Documentary about a 1984 hacker conference <sup>[7.4/10](http://www.imdb.com/title/tt1191116/)</sup>
 
 ### Reflective interviews
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of computer history videos, documentaries and related folklore ma
 
 ### Documentaries
 
+- [Hackers: Wizards of the Electronic Age](https://www.youtube.com/watch?v=cVCLowi4v7w) (1984) - Documentary about a 1984 hacker conference <sup>[7.4/10](http://www.imdb.com/title/tt1191116/)</sup>
 - [The KGB, the Computer, and Me](https://www.youtube.com/watch?v=EcKxaq1FTac) (1990) - With computer scientist Clifford Stoll <sup>[8.3/10](http://www.imdb.com/title/tt0308449/)</sup>
 - [Triumph of the Nerds: The Rise of Accidental Empires](https://en.wikipedia.org/wiki/Triumph_of_the_Nerds) (1996) - History of the personal computer <sup>[8.5/10](http://www.imdb.com/title/tt0115398/)</sup>
 - [Code Rush](https://www.youtube.com/watch?v=4Q7FTjhvZ7Y) (2000) - The story of Netscape and the birth of Mozilla <sup>[7.3/10](http://www.imdb.com/title/tt0499004/)</sup>
@@ -47,7 +48,6 @@ A curated list of computer history videos, documentaries and related folklore ma
 - [Silicon Valley](http://www.pbs.org/wgbh/americanexperience/films/silicon/) (2013) - A PBS "American Experience" documentary about the start of Silicon Valley <sup>[8.1/10](http://www.imdb.com/title/tt2547530/)</sup>
 - [Birth of BASIC](https://www.youtube.com/watch?v=WYPNjSoDrqw) (2014) - Invention of the Basic computer language.
 - [The Internet's Own Boy: The Story of Aaron Swartz](https://www.youtube.com/watch?v=vXr-2hwTk58) (2014) - The story of programming prodigy and information activist Aaron Swartz <sup>[8.1/10](http://www.imdb.com/title/tt3268458/)</sup>
-- [Hackers: Wizards of the Electronic Age](https://www.youtube.com/watch?v=cVCLowi4v7w) (1984) - Documentary about a 1984 hacker conference <sup>[7.4/10](http://www.imdb.com/title/tt1191116/)</sup>
 
 ### Reflective interviews
 


### PR DESCRIPTION
Added the documentary [Hackers: Wizards of the Electronic Age](https://www.youtube.com/watch?v=cVCLowi4v7w).

Hackers is a classic documentary about the midnight programmers that created the personal computer revolution.

Hackers is not about malicious code-crackers. It is about a hacker ethic that led to major breakthroughs in technology, and forever changed our world. From the first MIT hackers to popular Silicon Valley inventors, this program covers this fascinating cultural phenomenon through interviews with twelve of its early pioneers.

The program features conversations with: Steve Wozniak, designer of the Apple II; Bill Atkinson and Andy Hertzfeld, designers of the Macintosh; Homebrew Computer Club leader Lee Felsenstein; MIT hackers Richard Stallman and Richard Greenblatt; and many more.

Hackers was produced over a decade before the advent of the Internet. All interviews were shot over a long week-end in 1984, at the first Hackers Conference, hosted by Whole Earth Catalog editors Stewart Brand and Kevin Kelly, in Sausalito, California. This event was inspired by Steven Levy's classic book Hackers Heroes of the Computer Revolution.

_Source:_ [IMDb](http://www.imdb.com/title/tt1191116/)