### PR TITLE
Add Steve Jobs: The Lost Interview

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ _Dramatized versions of real events_
 
 ### Folklore
 
-- [The Humble Programmer](http://userweb.cs.utexas.edu/~EWD/transcriptions/EWD03xx/EWD340.html) (1972) - Edsger W. Dijkstra's discourse after receiving the Alan Turing prize
 - [Real Programmers Don't Use PASCAL](http://web.mit.edu/humor/Computers/real.programmers) (1982)
 - [Epigrams on Programming](http://www.cs.yale.edu/homes/perlis-alan/quotes.html) (1982)
 - [The Story of Mel](http://www.catb.org/jargon/html/story-of-mel.html) (1983)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ _Dramatized versions of real events_
 
 ### Folklore
 
-- [The Humble Programmer](https://www.cs.utexas.edu/users/EWD/ewd03xx/EWD340.PDF) (1972) - Edsger W. Dijkstra's discourse after receiving the Alan Turing prize
+- [The Humble Programmer](http://userweb.cs.utexas.edu/~EWD/transcriptions/EWD03xx/EWD340.html) (1972) - Edsger W. Dijkstra's discourse after receiving the Alan Turing prize
 - [Real Programmers Don't Use PASCAL](http://web.mit.edu/humor/Computers/real.programmers) (1982)
 - [Epigrams on Programming](http://www.cs.yale.edu/homes/perlis-alan/quotes.html) (1982)
 - [The Story of Mel](http://www.catb.org/jargon/html/story-of-mel.html) (1983)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ _Dramatized versions of real events_
 
 ### Folklore
 
-- [The Humble Programmer](http://userweb.cs.utexas.edu/~EWD/transcriptions/EWD03xx/EWD340.html) (1972) - Edsger W. Dijkstra's discourse after receiving the Alan Turing prize
+- [The Humble Programmer](https://www.cs.utexas.edu/users/EWD/ewd03xx/EWD340.PDF) (1972) - Edsger W. Dijkstra's discourse after receiving the Alan Turing prize
 - [Real Programmers Don't Use PASCAL](http://web.mit.edu/humor/Computers/real.programmers) (1982)
 - [Epigrams on Programming](http://www.cs.yale.edu/homes/perlis-alan/quotes.html) (1982)
 - [The Story of Mel](http://www.catb.org/jargon/html/story-of-mel.html) (1983)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ _Dramatized versions of real events_
 
 ### Folklore
 
+- [The Humble Programmer](http://userweb.cs.utexas.edu/~EWD/transcriptions/EWD03xx/EWD340.html) (1972) - Edsger W. Dijkstra's discourse after receiving the Alan Turing prize
 - [Real Programmers Don't Use PASCAL](http://web.mit.edu/humor/Computers/real.programmers) (1982)
 - [Epigrams on Programming](http://www.cs.yale.edu/homes/perlis-alan/quotes.html) (1982)
 - [The Story of Mel](http://www.catb.org/jargon/html/story-of-mel.html) (1983)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ A curated list of computer history videos, documentaries and related folklore ma
 
 ### Reflective interviews
 
+- [Steve Jobs: The Lost Interview](https://www.youtube.com/watch?v=TRZAJY23xio) (2012) - A conversation with Steve Jobs as he was running NeXT <sup>[8.1/10](http://www.imdb.com/title/tt2104994/)</sup>
 - [The Great 202 Jailbreak](https://www.youtube.com/watch?v=CVxeuwlvf8w) (2013) - David Brailsford
 - [UNIX Special: Profs Kernighan & Brailsford](https://www.youtube.com/watch?v=vT_J6xc-Az0) (2015) - David Brailsford interviews Brian Kernighan
 


### PR DESCRIPTION
Added the [Steve Jobs: The Lost Interview](https://www.youtube.com/watch?v=TRZAJY23xio) interview, which was hosted by the Robert X. Cringely. This interview is basically a conversation with Steve Jobs as he was running NeXT, the company he had founded after leaving Apple.