### PR TITLE
Add The Humble Programmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ _Dramatized versions of real events_
 
 ### Folklore
 
+- [The Humble Programmer](https://www.cs.utexas.edu/users/EWD/ewd03xx/EWD340.PDF) (1972) - Dijkstra's overview of the programming universe as he saw it in 1972
 - [Real Programmers Don't Use PASCAL](http://web.mit.edu/humor/Computers/real.programmers) (1982)
 - [Epigrams on Programming](http://www.cs.yale.edu/homes/perlis-alan/quotes.html) (1982)
 - [The Story of Mel](http://www.catb.org/jargon/html/story-of-mel.html) (1983)


### PR DESCRIPTION
Added the text “The Humble Programmer” ([text](http://www.cs.utexas.edu/~EWD/transcriptions/EWD03xx/EWD340.html), [PDF](http://www.cs.utexas.edu/users/EWD/ewd03xx/EWD340.PDF)). It's the Djisktra's discourse after receveing the ACM Alan Turing prize. It's an interesting view of the programming universe of the 60's and the 70's. 