### PR TITLE
Add the text How Steve Wozniak Wrote BASIC for the Original Apple

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Dramatized versions of real events_
 - [A Cypherpunk's Manifesto](https://w2.eff.org/Privacy/Crypto/Crypto_misc/cypherpunk.manifesto) (1993)
 - [In the Beginning…Was the Command Line](http://www.cryptonomicon.com/beginning.html) (1999)
 - [UTF-8 history](http://www.cl.cam.ac.uk/~mgk25/ucs/utf-8-history.txt) (2003)
+- [How Steve Wozniak Wrote BASIC for the Original Apple From Scratch](http://gizmodo.com/how-steve-wozniak-wrote-basic-for-the-original-apple-fr-1570573636) (2014)
 
 ### Announcements
 


### PR DESCRIPTION
Added the text [How Steve Wozniak Wrote BASIC for the Original Apple From Scratch](http://gizmodo.com/how-steve-wozniak-wrote-basic-for-the-original-apple-fr-1570573636).