### PR TITLE
Add Andy Hertzfeld's "The Original Macintosh" archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ _Dramatized versions of real events_
 
 ### Folklore
 
+- [The Original Macintosh](https://www.folklore.org/) - Anecdotes about the development of Apple's original Macintosh, and the people who made it
 - [The Humble Programmer](https://www.cs.utexas.edu/users/EWD/ewd03xx/EWD340.PDF) (1972) - Dijkstra's overview of the programming universe as he saw it in 1972
 - [Real Programmers Don't Use PASCAL](https://web.mit.edu/humor/Computers/real.programmers) (1982)
 - [Epigrams on Programming](http://www.cs.yale.edu/homes/perlis-alan/quotes.html) (1982)


### PR DESCRIPTION
Added "The Original Macintosh" -- https://www.folklore.org/ -- Anecdotes about the development of Apple's original Macintosh, and the people who made it (122 stories).