### PR TITLE
Add "Do you trust this computer?" to documentary

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ A curated list of computer history videos, documentaries and related folklore ma
 - [The Internet's Own Boy: The Story of Aaron Swartz](https://www.youtube.com/watch?v=vXr-2hwTk58) (2014) - The story of programming prodigy and information activist Aaron Swartz <sup>[8.1/10](https://www.imdb.com/title/tt3268458/)</sup>
 - [Rise of the Hackers](https://www.youtube.com/watch?v=dQnAEiGx1-4) (2014) - Harnessing cryptography to stay a step ahead of cybercriminals <sup>[7.5/10](https://www.imdb.com/title/tt3979842/)</sup>
 - [Silicon Cowboys](https://www.netflix.com/title/80104318) (2016) - Documentary detailing the story of Compaq, its three founders and how it took on IBM at the height of its PC dominance. <sup>[6.8/10](https://www.imdb.com/title/tt4938484/)</sup>
+- [Do You Trust This Computer?](https://www.youtube.com/watch?v=aV_IZye14vs) (2018) -  Documentary film that outlines the benefits and especially the dangers of artificial intelligence. <sup>[7.4/10](https://www.imdb.com/title/tt6152554/)</sup>
 
 ### Reflective interviews
 


### PR DESCRIPTION
I have added an unofficial link to the documentary because that was the easiest way to watch the documentary. Should I change it?

Unofficial link : https://www.youtube.com/watch?v=aV_IZye14vs
Official link(But could not stream directly) : http://doyoutrustthiscomputer.org/

Link to wikipedia : https://en.wikipedia.org/wiki/Do_You_Trust_This_Computer%3F 
Link to IMDb : https://www.imdb.com/title/tt6152554/