### PR TITLE
Update README.md for "Hackers Testifying at the United States Senate, May 19, 1998 (L0pht Heavy Industries)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,12 @@ A curated list of computer history videos, documentaries and related folklore ma
 ### Talks & Lectures
 
 - [Computers From The Inside Out](https://www.youtube.com/watch?v=EKWGGDXe5MA) (1985) - Richard Feynman Computer Heuristics Lecture. Not about computer history per se, but about how computers work
+- [Hackers Testifying at the United States Senate, May 19, 1998 (L0pht Heavy Industries)](https://www.youtube.com/watch?v=VVJldn_MmMY) (1998) - This was the first time that the United States Senate invited hackers to come and describe the state of cybersecurity. This is the infamous testimony where Mudge stated that the group could take down the Internet in 30 minutes. Established the legitimacy of white hat hackers to lawmakers.   
 - [The Origins of Linux - Linus Torvalds](https://www.youtube.com/watch?v=WVTWCPoUt8w) (2001) - Linus Torvalds tells the story of how he went from writing code as a graduate student to become an icon for open source software.
 - [The Secret History of Silicon Valley](https://www.youtube.com/watch?v=ZTC_RxWN_xo) (2008) - Talk by Steve Blank at the Computer History Museum
 - [Crockford on JavaScript - Volume 1: The Early Years](https://www.youtube.com/watch?v=JxAXlJEmNMg) (2011) - Not actually about JavaScript, but about early computing history
 - [Bret Victor - The Future of Programming](https://www.youtube.com/watch?v=8pTEmbeENF4) (2013..ehh 1973) - Humorous talk about the future of programming as seen from 1973
+- 
 
 ### Movies
 


### PR DESCRIPTION
Added a link to "Hackers Testifying at the United States Senate, May 19, 1998 (L0pht Heavy Industries)" in the Talks and Lectures section. Really important video that introduced the concept of white hat hackers to US lawmakers. Most of the folks from L0pht Heavy industries went on to do big things in cybersecurity. A couple of the guys founded Veracode. Mudge became the US government's go-to guy. It's amazing to see them testifying under their hacker pseudonyms. 

 https://www.youtube.com/watch?v=VVJldn_MmMY